### PR TITLE
Skip MEMZERO for struct/union initialized with assign

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1386,6 +1386,8 @@ static Node *lvar_initializer(Token **rest, Token *tok, Obj *var) {
   // we're done.
   if (var->ty->kind <= TY_PTR) return lvar_init;
 
+  if (init->expr) return lvar_init;
+
   // If a partial initializer list is given,
   // the standard requires that unspecified elements are set to 0.
   // Rather than work out whether the whole array/struct is covered,


### PR DESCRIPTION
At `lvar_initializer()`, if `init->expr` is provided it means it's initialized by assign expression, as long as the backend implement assign with full copy, it's safe to omit the memzero here.

This applies to with scenarios like:
```
struct S {
  long z[17];
  int i;
};
int fn(struct S *p) {
  struct S s = *p; // initialized by assign
  return s.i;
}
```